### PR TITLE
 Version 0.6: Improve documentation and Windows conventions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "directories"
-version     = "0.5.0"
+version     = "0.6.0"
 authors     = [ "Simon Ochsenreither <simon@ochsenreither.de>" ]
 description = "A tiny library that provides platform-specific standard locations of directories for config, cache, etc. data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base directory and the XDG user directory specifications on Linux, the Known Folder system on Windows, and the Standard Directory rules on macOS."
 readme      = "README.md"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The library provides the location of these directories by leveraging the mechani
 Add the library as a dependency to your project by inserting
 
 ```toml
-directories = "0.5.0"
+directories = "0.6.0"
 ```
 
 into the `[dependencies]` section of your Cargo.toml file.
@@ -39,7 +39,7 @@ use directories::ProjectDirs;
 let proj_dirs = ProjectDirs::from("com", "Foo Corp",  "Bar App");
 proj_dirs.config_dir();
 // Linux:   /home/alice/.config/barapp/
-// Windows: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App
+// Windows: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config\
 // macOS:   /Users/Alice/Library/Preferences/com.Foo-Corp.Bar-App
 ```
 
@@ -48,14 +48,14 @@ proj_dirs.config_dir();
 ### `BaseDirs`
 
 The intended use-case for `BaseDirs` is to query the paths of standard directories
-that have been defined according to the conventions of operating system the library is running on.
+that have been defined according to the conventions of the operating system the library is running on.
 
 If you want to compute the location of cache, config or data directories for your own application or project, use `ProjectDirs` instead.
 
 | Function name    | Value on Linux                                                                               | Value on Windows                 | Value on macOS                       |
 | ---------------- | -------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------ |
 | `home_dir`       | `$HOME`                                                                                      | `{FOLDERID_Profile}`             | `$HOME`                              |
-| `cache_dir`      | `$XDG_CACHE_HOME`             or `~/.cache/`                                                 | `{FOLDERID_LocalAppData}/cache/` | `$HOME/Library/Caches/`              |
+| `cache_dir`      | `$XDG_CACHE_HOME`             or `~/.cache/`                                                 | `{FOLDERID_LocalAppData}` | `$HOME/Library/Caches/`              |
 | `config_dir`     | `$XDG_CONFIG_HOME`            or `~/.config/`                                                | `{FOLDERID_RoamingAppData}`      | `$HOME/Library/Preferences/`         |
 | `data_dir`       | `$XDG_DATA_HOME`              or `~/.local/share/`                                           | `{FOLDERID_RoamingAppData}`      | `$HOME/Library/Application Support/` |
 | `data_local_dir` | `$XDG_DATA_HOME`              or `~/.local/share/`                                           | `{FOLDERID_LocalAppData}`        | `$HOME/Library/Application Support/` |
@@ -90,8 +90,8 @@ The specific value of `_project_path_` is computed by the
 
 function and varies across operating systems. As an example, calling
 
-    ProjectDirs::from("org" /*qualifier*/, "Baz Corp" /*organization*/, "Foo Bar-App" /*project*/)
-    
+    ProjectDirs::from("org" /*qualifier*/, "Baz Corp" /*organization*/, "Foo Bar-App" /*application*/)
+
 results in the following values:
 
 | Value on Linux | Value on Windows         | Value on macOS               |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,17 @@
+//! The _directories_ crate is
+//!
+//! - a tiny library with a minimal API (2 structs, 3 factory functions, getters)
+//! - that provides the platform-specific, user-accessible locations
+//! - for storing configuration, cache and other data
+//! - on Linux, Windows (≥ Vista) and macOS.
+//!
+//! The library provides the location of these directories by leveraging the mechanisms defined by
+//!
+//! - the [XDG base directory](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) and the [XDG user directory](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) specifications on Linux,
+//! - the [Known Folder](https://msdn.microsoft.com/en-us/library/windows/desktop/bb776911(v=vs.85).aspx) system on Windows, and
+//! - the [Standard Directories](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW6) on macOS.
+//! 
+
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -46,70 +60,93 @@ pub struct ProjectDirs {
     runtime_dir:    Option<PathBuf>
 }
 
+/// `BaseDirs` provides paths to standard directories, following the conventions of the operating system the library is running on.
+///
+/// To compute the location of cache, config or data directories for individual projects or applications, use `ProjectDirs` instead.
+/// 
+/// # Examples
+/// 
+/// All examples on this page are computed with a user named _Alice_.
+/// 
+/// ```
+/// use directories::base_dirs;
+/// 
+/// let base_dirs = base_dirs();
+/// 
+/// base_dirs.config_dir();
+/// // Linux:   /home/alice/.config/
+/// // Windows: C:\Users\Alice\AppData\Roaming\
+/// // macOS:   /Users/Alice/Library/Preferences/
+/// 
+/// base_dirs.audio_dir();
+/// // Linux:   /home/alice/Music/
+/// // Windows: /Users/Alice/Music/
+/// // macOS:   C:\Users\Alice\Music\
+/// ```
 #[deny(missing_docs)]
 impl BaseDirs {
     /// Returns the path to the user's home directory.
     ///
-    /// |Platform | Value                | Example       |
-    /// | ------- | -------------------- | ------------- |
-    /// | Linux   | `$HOME`              | /home/eve/    |
-    /// | macOS   | `$HOME`              | /Users/eve/   |
-    /// | Windows | `{FOLDERID_Profile}` | C:\Users\Eve\ |
+    /// |Platform | Value                | Example         |
+    /// | ------- | -------------------- | --------------- |
+    /// | Linux   | `$HOME`              | /home/alice/    |
+    /// | macOS   | `$HOME`              | /Users/Alice/   |
+    /// | Windows | `{FOLDERID_Profile}` | C:\Users\Alice\ |
     pub fn home_dir(&self) -> &Path {
         self.home_dir.as_path()
     }
     /// Returns the path to the user's cache directory.
-    /// 
-    /// |Platform | Value                             | Example                           |
-    /// | ------- | --------------------------------- | --------------------------------- |
-    /// | Linux   | `$XDG_CACHE_HOME` or `~/.cache/`  | /home/eve/.cache/                 |
-    /// | macOS   | `$HOME/Library/Caches/`           | /Users/eve/Library/Caches/        |
-    /// | Windows | `{FOLDERID_LocalAppData}\cache\`  | C:\Users\Eve\AppData\Local\cache\ |
+    ///
+    /// |Platform | Value                             | Example                       |
+    /// | ------- | --------------------------------- | ----------------------------- |
+    /// | Linux   | `$XDG_CACHE_HOME` or `~/.cache/`  | /home/alice/.cache/           |
+    /// | macOS   | `$HOME/Library/Caches/`           | /Users/Alice/Library/Caches/  |
+    /// | Windows | `{FOLDERID_LocalAppData}\cache\`  | C:\Users\Alice\AppData\Local\ |
     pub fn cache_dir(&self) -> &Path {
         self.cache_dir.as_path()
     }
     /// Returns the path to the user's config directory.
-    /// 
-    /// |Platform | Value                              | Example                         |
-    /// | ------- | ---------------------------------- | ------------------------------- |
-    /// | Linux   | `$XDG_CONFIG_HOME` or `~/.config/` | /home/eve/.config               |
-    /// | macOS   | `$HOME/Library/Preferences/`       | /Users/eve/Library/Preferences/ |
-    /// | Windows | `{FOLDERID_RoamingAppData}`        | C:\Users\Eve\AppData\Roaming\   |
+    ///
+    /// |Platform | Value                              | Example                           |
+    /// | ------- | ---------------------------------- | --------------------------------- |
+    /// | Linux   | `$XDG_CONFIG_HOME` or `~/.config/` | /home/alice/.config               |
+    /// | macOS   | `$HOME/Library/Preferences/`       | /Users/Alice/Library/Preferences/ |
+    /// | Windows | `{FOLDERID_RoamingAppData}`        | C:\Users\Alice\AppData\Roaming\   |
     pub fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
     }
     /// Returns the path to the user's data directory.
-    /// 
-    /// |Platform | Value                                 | Example                                 |
-    /// | ------- | ------------------------------------- | --------------------------------------- |
-    /// | Linux   | `$XDG_DATA_HOME` or `~/.local/share/` | /home/eve/.local/share/                 |
-    /// | macOS   | `$HOME/Library/Application Support/`  | /Users/eve/Library/Application Support/ |
-    /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Eve\AppData\Roaming\           |
+    ///
+    /// |Platform | Value                                 | Example                                   |
+    /// | ------- | ------------------------------------- | ----------------------------------------- |
+    /// | Linux   | `$XDG_DATA_HOME` or `~/.local/share/` | /home/alice/.local/share/                 |
+    /// | macOS   | `$HOME/Library/Application Support/`  | /Users/Alice/Library/Application Support/ |
+    /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming\           |
     pub fn data_dir(&self) -> &Path {
         self.data_dir.as_path()
     }
     /// Returns the path to the user's local data directory.
-    /// 
-    /// |Platform | Value                                 | Example                                 |
-    /// | ------- | ------------------------------------- | --------------------------------------- |
-    /// | Linux   | `$XDG_DATA_HOME` or `~/.local/share/` | /home/eve/.local/share/                 |
-    /// | macOS   | `$HOME/Library/Application Support/`  | /Users/eve/Library/Application Support/ |
-    /// | Windows | `{FOLDERID_LocalAppData}`             | C:\Users\Eve\AppData\Local\             |
+    ///
+    /// |Platform | Value                                 | Example                                   |
+    /// | ------- | ------------------------------------- | ----------------------------------------- |
+    /// | Linux   | `$XDG_DATA_HOME` or `~/.local/share/` | /home/alice/.local/share/                 |
+    /// | macOS   | `$HOME/Library/Application Support/`  | /Users/Alice/Library/Application Support/ |
+    /// | Windows | `{FOLDERID_LocalAppData}`             | C:\Users\Alice\AppData\Local\             |
     pub fn data_local_dir(&self) -> &Path {
         self.data_local_dir.as_path()
     }
     /// Returns the path to the user's executable directory.
-    /// 
+    ///
     /// |Platform | Value                                                          | Example                  |
     /// | ------- | -------------------------------------------------------------- | ------------------------ |
-    /// | Linux   | `$XDG_BIN_HOME/` or `$XDG_DATA_HOME/../bin/` or `~/.local/bin` | /home/eve/.local/bin/    |
+    /// | Linux   | `$XDG_BIN_HOME/` or `$XDG_DATA_HOME/../bin/` or `~/.local/bin` | /home/alice/.local/bin/  |
     /// | macOS   | –                                                              | –                        |
     /// | Windows | –                                                              | –                        |
     pub fn executable_dir(&self) -> Option<&Path> {
         self.executable_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's runtime directory.
-    /// 
+    ///
     /// |Platform | Value              | Example         |
     /// | ------- | ------------------ | --------------- |
     /// | Linux   | `$XDG_RUNTIME_DIR` | /run/user/1001/ |
@@ -120,113 +157,168 @@ impl BaseDirs {
     }
 
     /// Returns the path to the user's audio directory.
-    /// 
-    /// |Platform | Value              | Example             |
-    /// | ------- | ------------------ | ------------------- |
-    /// | Linux   | `XDG_MUSIC_DIR`    | /home/eve/Music/    |
-    /// | macOS   | `$HOME/Music/`     | /Users/eve/Music/   |
-    /// | Windows | `{FOLDERID_Music}` | C:\Users\Eve\Music\ |
+    ///
+    /// |Platform | Value              | Example               |
+    /// | ------- | ------------------ | --------------------- |
+    /// | Linux   | `XDG_MUSIC_DIR`    | /home/alice/Music/    |
+    /// | macOS   | `$HOME/Music/`     | /Users/Alice/Music/   |
+    /// | Windows | `{FOLDERID_Music}` | C:\Users\Alice\Music\ |
     pub fn audio_dir(&self) -> Option<&Path> {
         self.audio_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's desktop directory.
-    /// 
-    /// |Platform | Value              | Example                 |
-    /// | ------- | ------------------ | ----------------------- |
-    /// | Linux   | `XDG_DESKTOP_DIR`    | /home/eve/Desktop/    |
-    /// | macOS   | `$HOME/Desktop/`     | /Users/eve/Desktop/   |
-    /// | Windows | `{FOLDERID_Desktop}` | C:\Users\Eve\Desktop\ |
+    ///
+    /// |Platform | Value                | Example                 |
+    /// | ------- | -------------------- | ----------------------- |
+    /// | Linux   | `XDG_DESKTOP_DIR`    | /home/alice/Desktop/    |
+    /// | macOS   | `$HOME/Desktop/`     | /Users/Alice/Desktop/   |
+    /// | Windows | `{FOLDERID_Desktop}` | C:\Users\Alice\Desktop\ |
     pub fn desktop_dir(&self) -> Option<&Path> {
         self.desktop_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's document directory.
-    /// 
-    /// |Platform | Value                  | Example                 |
-    /// | ------- | ---------------------- | ----------------------- |
-    /// | Linux   | `XDG_DOCUMENTS_DIR`    | /home/eve/Documents/    |
-    /// | macOS   | `$HOME/Documents/`     | /Users/eve/Documents/   |
-    /// | Windows | `{FOLDERID_Documents}` | C:\Users\Eve\Documents\ |
+    ///
+    /// |Platform | Value                  | Example                   |
+    /// | ------- | ---------------------- | ------------------------- |
+    /// | Linux   | `XDG_DOCUMENTS_DIR`    | /home/alice/Documents/    |
+    /// | macOS   | `$HOME/Documents/`     | /Users/Alice/Documents/   |
+    /// | Windows | `{FOLDERID_Documents}` | C:\Users\Alice\Documents\ |
     pub fn document_dir(&self) -> Option<&Path> {
         self.document_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's download directory.
-    /// 
-    /// |Platform | Value                  | Example                 |
-    /// | ------- | ---------------------- | ----------------------- |
-    /// | Linux   | `XDG_DOWNLOAD_DIR`     | /home/eve/Downloads/    |
-    /// | macOS   | `$HOME/Downloads/`     | /Users/eve/Downloads/   |
-    /// | Windows | `{FOLDERID_Downloads}` | C:\Users\Eve\Downloads\ |
+    ///
+    /// |Platform | Value                  | Example                   |
+    /// | ------- | ---------------------- | ------------------------- |
+    /// | Linux   | `XDG_DOWNLOAD_DIR`     | /home/alice/Downloads/    |
+    /// | macOS   | `$HOME/Downloads/`     | /Users/Alice/Downloads/   |
+    /// | Windows | `{FOLDERID_Downloads}` | C:\Users\Alice\Downloads\ |
     pub fn download_dir(&self) -> Option<&Path> {
         self.download_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's font directory.
-    /// 
-    /// |Platform | Value                                                  | Example                       |
-    /// | ------- | ------------------------------------------------------ | ----------------------------- |
-    /// | Linux   | `$XDG_DATA_HOME/fonts/` or `$HOME/.local/share/fonts/` | /home/eve/.local/share/fonts/ |
-    /// | macOS   | `$HOME/Library/Fonts/`                                 | /Users/eve/Library/Fonts/     |
-    /// | Windows | –                                                      | –                             |
+    ///
+    /// |Platform | Value                                                  | Example                         |
+    /// | ------- | ------------------------------------------------------ | ------------------------------- |
+    /// | Linux   | `$XDG_DATA_HOME/fonts/` or `$HOME/.local/share/fonts/` | /home/alice/.local/share/fonts/ |
+    /// | macOS   | `$HOME/Library/Fonts/`                                 | /Users/Alice/Library/Fonts/     |
+    /// | Windows | –                                                      | –                               |
     pub fn font_dir(&self) -> Option<&Path> {
         self.font_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's picture directory.
-    /// 
-    /// |Platform | Value                 | Example                |
-    /// | ------- | --------------------- | ---------------------- |
-    /// | Linux   | `XDG_PICTURES_DIR`    | /home/eve/Pictures/    |
-    /// | macOS   | `$HOME/Pictures/`     | /Users/eve/Pictures/   |
-    /// | Windows | `{FOLDERID_Pictures}` | C:\Users\Eve\Pictures\ |
+    ///
+    /// |Platform | Value                 | Example                  |
+    /// | ------- | --------------------- | ------------------------ |
+    /// | Linux   | `XDG_PICTURES_DIR`    | /home/alice/Pictures/    |
+    /// | macOS   | `$HOME/Pictures/`     | /Users/Alice/Pictures/   |
+    /// | Windows | `{FOLDERID_Pictures}` | C:\Users\Alice\Pictures\ |
     pub fn picture_dir(&self) -> Option<&Path> {
         self.picture_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's public directory.
-    /// 
-    /// |Platform | Value                 | Example            |
-    /// | ------- | --------------------- | ------------------ |
-    /// | Linux   | `XDG_PUBLICSHARE_DIR` | /home/eve/Public/  |
-    /// | macOS   | `$HOME/Public/`       | /Users/eve/Public/ |
-    /// | Windows | `{FOLDERID_Public}`   | C:\Users\Public\   |
+    ///
+    /// |Platform | Value                 | Example              |
+    /// | ------- | --------------------- | -------------------- |
+    /// | Linux   | `XDG_PUBLICSHARE_DIR` | /home/alice/Public/  |
+    /// | macOS   | `$HOME/Public/`       | /Users/Alice/Public/ |
+    /// | Windows | `{FOLDERID_Public}`   | C:\Users\Public\     |
     pub fn public_dir(&self) -> Option<&Path> {
         self.public_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's template directory.
-    /// 
-    /// |Platform | Value                  | Example                                                   |
-    /// | ------- | ---------------------- | --------------------------------------------------------- |
-    /// | Linux   | `XDG_TEMPLATES_DIR`    | /home/eve/Templates/                                      |
-    /// | macOS   | –                      | –                                                         |
-    /// | Windows | `{FOLDERID_Templates}` | C:\Users\Eve\AppData\Roaming\Microsoft\Windows\Templates\ |
+    ///
+    /// |Platform | Value                  | Example                                                     |
+    /// | ------- | ---------------------- | ----------------------------------------------------------- |
+    /// | Linux   | `XDG_TEMPLATES_DIR`    | /home/alice/Templates/                                      |
+    /// | macOS   | –                      | –                                                           |
+    /// | Windows | `{FOLDERID_Templates}` | C:\Users\Alice\AppData\Roaming\Microsoft\Windows\Templates\ |
     pub fn template_dir(&self) -> Option<&Path> {
         self.template_dir.as_ref().map(|p| p.as_path())
     }
     /// Returns the path to the user's video directory.
-    /// 
-    /// |Platform | Value               | Example              |
-    /// | ------- | ------------------- | -------------------- |
-    /// | Linux   | `XDG_VIDEOS_DIR`    | /home/eve/Videos/    |
-    /// | macOS   | `$HOME/Movies/`     | /Users/eve/Movies/   |
-    /// | Windows | `{FOLDERID_Videos}` | C:\Users\Eve\Videos\ |
+    ///
+    /// |Platform | Value               | Example                |
+    /// | ------- | ------------------- | ---------------------- |
+    /// | Linux   | `XDG_VIDEOS_DIR`    | /home/alice/Videos/    |
+    /// | macOS   | `$HOME/Movies/`     | /Users/Alice/Movies/   |
+    /// | Windows | `{FOLDERID_Videos}` | C:\Users\Alice\Videos\ |
     pub fn video_dir(&self) -> Option<&Path> {
         self.video_dir.as_ref().map(|p| p.as_path())
     }
 }
 
+/// `ProjectDirs` computes the location of cache, config or data directories for a specific application,
+/// which are derived from the standard directories and the name of the project/organization.
+/// 
+/// # Examples
+/// 
+/// All examples on this page are computed with a user named _Alice_,
+/// and a `ProjectDirs` struct created with `ProjectDirs::from("com", "Foo Corp", "Bar App")`.
+/// 
+/// ```
+/// use directories::ProjectDirs;
+///
+/// let proj_dirs = ProjectDirs::from("com", "Foo Corp",  "Bar App");
+/// proj_dirs.config_dir();
+/// // Linux:   /home/alice/.config/barapp/
+/// // Windows: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App
+/// // macOS:   /Users/Alice/Library/Preferences/com.Foo-Corp.Bar-App
+/// ```
+#[deny(missing_docs)]
 impl ProjectDirs {
+    /// Returns the project path fragment used to compute the project's cache/config/data directories.
+    /// The value is derived from the `ProjectDirs::from` call and is platform-dependent.
     pub fn project_path(&self) -> &Path {
         self.project_path.as_path()
     }
+    /// Returns the path to the project's cache directory.
+    /// 
+    /// |Platform | Value                                                          | Example                                                 |
+    /// | ------- | -------------------------------------------------------------- | ------------------------------------------------------- |
+    /// | Linux   | `$XDG_CACHE_HOME_project_path_/` or `~/.cache/_project_path_/` | /home/alice/.cache/barapp/                              |
+    /// | macOS   | `$HOME/Library/Caches/_project_path_/`                         | /Users/Alice/Library/Caches/com.Foo-Corp.Bar-App/cache/ |
+    /// | Windows | `{FOLDERID_LocalAppData}\_project_path_\cache\`                | C:\Users\Alice\AppData\Local\Foo Corp\Bar App\cache\    |
     pub fn cache_dir(&self) -> &Path {
         self.cache_dir.as_path()
     }
+    /// Returns the path to the project's config directory.
+    /// 
+    /// |Platform | Value                                                             | Example                                                      |
+    /// | ------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
+    /// | Linux   | `$XDG_CONFIG_HOME/_project_path_/` or `~/.config/_project_path_/` | /home/alice/.config/barapp/                                  |
+    /// | macOS   | `$HOME/Library/Preferences/_project_path_/`                       | /Users/Alice/Library/Preferences/com.Foo-Corp.Bar-App/cache/ |
+    /// | Windows | `{FOLDERID_RoamingAppData}\_project_path_\config\`                | C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config\      |
     pub fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
     }
+    /// Returns the path to the project's data directory.
+    /// 
+    /// |Platform | Value                                                                | Example                                                             |
+    /// | ------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+    /// | Linux   | `$XDG_DATA_HOME/_project_path_/` or `~/.local/share/_project_path_/` | /home/alice/.local/share/barapp/                                    |
+    /// | macOS   | `$HOME/Library/Application Support/_project_path_/`                  | /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App/data/ |
+    /// | Windows | `{FOLDERID_RoamingAppData}\_project_path_\data\`                     | C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\data\               |
     pub fn data_dir(&self) -> &Path {
         self.data_dir.as_path()
     }
+    /// Returns the path to the project's local data directory.
+    /// 
+    /// |Platform | Value                                                                | Example                                                             |
+    /// | ------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+    /// | Linux   | `$XDG_DATA_HOME/_project_path_/` or `~/.local/share/_project_path_/` | /home/alice/.local/share/barapp/                                    |
+    /// | macOS   | `$HOME/Library/Application Support/_project_path_/`                  | /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App/data/ |
+    /// | Windows | `{FOLDERID_LocalAppData}\_project_path_\data\`                       | C:\Users\Alice\AppData\Local\Foo Corp\Bar App\data\                 |
     pub fn data_local_dir(&self) -> &Path {
         self.data_local_dir.as_path()
     }
+    /// Returns the path to the project's runtime directory.
+    /// 
+    /// |Platform | Value              | Example                |
+    /// | ------- | ------------------ | ---------------------- |
+    /// | Linux   | `$XDG_RUNTIME_DIR` | /run/user/1001/barapp/ |
+    /// | macOS   | –                  | –                      |
+    /// | Windows | –                  | –                      |
     pub fn runtime_dir(&self) -> Option<&Path> {
         self.runtime_dir.as_ref().map(|p| p.as_path())
     }

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use BaseDirs;
 use ProjectDirs;
 
+#[cfg(target_os = "linux")]
 pub fn base_dirs() -> BaseDirs {
     let home_dir       = env::home_dir().unwrap();
     let cache_dir      = env::var("XDG_CACHE_HOME") .ok().and_then(is_absolute_path).unwrap_or(home_dir.join(".cache"));
@@ -38,7 +39,13 @@ pub fn base_dirs() -> BaseDirs {
     }
 }
 
+#[deny(missing_docs)]
 impl ProjectDirs {
+    /// Creates a `ProjectDirs` struct directly from a `PathBuf` value.
+    /// The argument is used verbatim and is not adapted to operating system standards.
+    /// 
+    /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
+    /// not follow operating system standards on at least two of three platforms.
     pub fn from_path(project_path: PathBuf) -> ProjectDirs {
         let home_dir       = env::home_dir().unwrap();
         let cache_dir      = env::var("XDG_CACHE_HOME") .ok().and_then(is_absolute_path).unwrap_or(home_dir.join(".cache")).join(&project_path);
@@ -57,11 +64,25 @@ impl ProjectDirs {
         }
     }
 
+    /// Creates a `ProjectDirs` struct from values describing the project.
+    ///
+    /// The use of `ProjectDirs::from` (instead of `ProjectDirs::from_path`) is strongly encouraged,
+    /// as its results will follow operating system standards on Linux, macOS and Windows.
+    ///
+    /// # Parameters
+    ///
+    /// - `qualifier`    – The reverse domain name notation of the application, excluding the organization or application name itself.<br/>
+    ///   An empty string can be passed if no qualifier should be used (only affects macOS).<br/>
+    ///   Example values: `"com.example"`, `"org"`, `"uk.co"`, `"io"`, `""`
+    /// - `organization` – The name of the organization that develops this application, or for which the application is developed.<br/>
+    ///   An empty string can be passed if no organization should be used (only affects macOS and Windows).<br/>
+    ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`
+    /// - `application`  – The name of the application itself.<br/>
+    ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
     #[allow(unused_variables)]
-    pub fn from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
-        ProjectDirs::from_path(PathBuf::from(&trim_and_lowercase_then_replace_spaces(project, "")))
+    pub fn from(qualifier: &str, organization: &str, application: &str) -> ProjectDirs {
+        ProjectDirs::from_path(PathBuf::from(&trim_and_lowercase_then_replace_spaces(application, "")))
     }
-
 }
 
 fn is_absolute_path(path: String) -> Option<PathBuf> {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -41,7 +41,13 @@ pub fn base_dirs() -> BaseDirs {
     }
 }
 
+#[deny(missing_docs)]
 impl ProjectDirs {
+    /// Creates a `ProjectDirs` struct directly from a `PathBuf` value.
+    /// The argument is used verbatim and is not adapted to operating system standards.
+    /// 
+    /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
+    /// not follow operating system standards on at least two of three platforms.
     pub fn from_path(project_path: PathBuf) -> ProjectDirs {
         let home_dir       = env::home_dir().unwrap();
         let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
@@ -59,6 +65,21 @@ impl ProjectDirs {
         }
     }
 
+    /// Creates a `ProjectDirs` struct from values describing the project.
+    ///
+    /// The use of `ProjectDirs::from` (instead of `ProjectDirs::from_path`) is strongly encouraged,
+    /// as its results will follow operating system standards on Linux, macOS and Windows.
+    ///
+    /// # Parameters
+    ///
+    /// - `qualifier`    – The reverse domain name notation of the application, excluding the organization or application name itself.<br/>
+    ///   An empty string can be passed if no qualifier should be used (only affects macOS).<br/>
+    ///   Example values: `"com.example"`, `"org"`, `"uk.co"`, `"io"`, `""`
+    /// - `organization` – The name of the organization that develops this application, or for which the application is developed.<br/>
+    ///   An empty string can be passed if no organization should be used (only affects macOS and Windows).<br/>
+    ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`
+    /// - `application`  – The name of the application itself.<br/>
+    ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
     #[allow(unused_variables)]
     pub fn from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
         // we should replace more characters, according to RFC1034 identifier rules


### PR DESCRIPTION
Documentation:

- Added missing documentation on impls and fns, pretty much everything
  public should be documented now.
- Update README and documentation on Windows changes

Windows:

- BaseDirs::cache_dir points to {FOLDERID_LocalAppData},
  not {FOLDERID_LocalAppData}\cache\
- ProjectDirs now point to sub-directories on Windows:
  - ProjectDirs.cache_dir: {FOLDERID_LocalAppData}\_project_path_\cache\
  - ProjectDirs.config_dir: {FOLDERID_RoamingAppData}\_project_path_\config\
  - ProjectDirs.data_dir: {FOLDERID_RoamingAppData}\_project_path_\data\
  - ProjectDirs.data_local_dir: {FOLDERID_LocalAppData}\_project_path_\data\
- See https://github.com/soc/directories-rs/issues/9 for the reasoning behind the changes.