### PR TITLE
Fix some docs, add panic section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,21 @@ pub struct ProjectDirs {
 impl BaseDirs {
     /// Returns the path to the user's home directory.
     ///
-    /// |Platform | Value                | Example         |
-    /// | ------- | -------------------- | --------------- |
-    /// | Linux   | `$HOME`              | /home/alice     |
-    /// | macOS   | `$HOME`              | /Users/Alice    |
-    /// | Windows | `{FOLDERID_Profile}` | C:\Users\Alice\ |
+    /// |Platform | Value                 | Example         |
+    /// | ------- | --------------------- | --------------- |
+    /// | Linux   | `$HOME` with fallback | /home/alice     |
+    /// | macOS   | `$HOME` with fallback | /Users/Alice    |
+    /// | Windows | `{FOLDERID_Profile}`  | C:\Users\Alice\ |
+    ///
+    /// On Linux and macOS, this function just uses [`std::env::home_dir`] to
+    /// determine the home directory, with the same fallback. If `$HOME` is not
+    /// set, the function `getpwuid_r` is used to determine the home directory
+    /// of the current user. If that also fails, creation of `BaseDirs` panics.
+    ///
+    /// All the examples on this page mentioning `$HOME` will also use this
+    /// fallback.
+    ///
+    /// [`std::env::home_dir`]: https://doc.rust-lang.org/std/env/fn.home_dir.html
     pub fn home_dir(&self) -> &Path {
         self.home_dir.as_path()
     }
@@ -127,7 +137,7 @@ impl BaseDirs {
     /// | ------- | ----------------------------------- | ---------------------------- |
     /// | Linux   | `$XDG_CACHE_HOME` or `$HOME/.cache` | /home/alice/.cache           |
     /// | macOS   | `$HOME/Library/Caches`              | /Users/Alice/Library/Caches  |
-    /// | Windows | `{FOLDERID_LocalAppData}\cache`     | C:\Users\Alice\AppData\Local |
+    /// | Windows | `{FOLDERID_LocalAppData}`           | C:\Users\Alice\AppData\Local |
     pub fn cache_dir(&self) -> &Path {
         self.cache_dir.as_path()
     }
@@ -187,11 +197,21 @@ impl BaseDirs {
 impl UserDirs {
     /// Returns the path to the user's home directory.
     ///
-    /// |Platform | Value                | Example        |
-    /// | ------- | -------------------- | -------------- |
-    /// | Linux   | `$HOME`              | /home/alice    |
-    /// | macOS   | `$HOME`              | /Users/Alice   |
-    /// | Windows | `{FOLDERID_Profile}` | C:\Users\Alice |
+    /// |Platform | Value                 | Example        |
+    /// | ------- | --------------------- | -------------- |
+    /// | Linux   | `$HOME` with fallback | /home/alice    |
+    /// | macOS   | `$HOME` with fallback | /Users/Alice   |
+    /// | Windows | `{FOLDERID_Profile}`  | C:\Users\Alice |
+    ///
+    /// On Linux and macOS, this function just uses [`std::env::home_dir`] to
+    /// determine the home directory, with the same fallback. If `$HOME` is not
+    /// set, the function `getpwuid_r` is used to determine the home directory
+    /// of the current user. If that also fails, creation of `BaseDirs` panics.
+    ///
+    /// All the examples on this page mentioning `$HOME` will also use this
+    /// fallback.
+    ///
+    /// [`std::env::home_dir`]: https://doc.rust-lang.org/std/env/fn.home_dir.html
     pub fn home_dir(&self) -> &Path {
         self.home_dir.as_path()
     }
@@ -308,11 +328,11 @@ impl ProjectDirs {
     }
     /// Returns the path to the project's cache directory.
     /// 
-    /// |Platform | Value                                                            | Example                                             |
-    /// | ------- | ---------------------------------------------------------------- | --------------------------------------------------- |
-    /// | Linux   | `$XDG_CACHE_HOME_project_path_` or `$HOME/.cache/_project_path_` | /home/alice/.cache/barapp                           |
-    /// | macOS   | `$HOME/Library/Caches/_project_path_`                            | /Users/Alice/Library/Caches/com.Foo-Corp.Bar-App    |
-    /// | Windows | `{FOLDERID_LocalAppData}\_project_path_\cache`                   | C:\Users\Alice\AppData\Local\Foo Corp\Bar App\cache |
+    /// |Platform | Value                                                             | Example                                             |
+    /// | ------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+    /// | Linux   | `$XDG_CACHE_HOME/_project_path_` or `$HOME/.cache/_project_path_` | /home/alice/.cache/barapp                           |
+    /// | macOS   | `$HOME/Library/Caches/_project_path_`                             | /Users/Alice/Library/Caches/com.Foo-Corp.Bar-App    |
+    /// | Windows | `{FOLDERID_LocalAppData}\_project_path_\cache`                    | C:\Users\Alice\AppData\Local\Foo Corp\Bar App\cache |
     pub fn cache_dir(&self) -> &Path {
         self.cache_dir.as_path()
     }

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -13,6 +13,12 @@ use ProjectDirs;
 impl BaseDirs {
     /// Creates a `BaseDirs` struct which holds the paths to user-invisible directories for cache, config, etc. data on the system.
     /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`home_dir`].
+    ///
+    /// [`home_dir`]: #method.home_dir
     pub fn new() -> BaseDirs {
         let home_dir       = env::home_dir().unwrap();
         let cache_dir      = env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).unwrap_or_else(|| home_dir.join(".cache"));
@@ -39,6 +45,12 @@ impl BaseDirs {
 impl UserDirs {
     /// Creates a `UserDirs` struct which holds the paths to user-facing directories for audio, font, video, etc. data on the system.
     /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`home_dir`].
+    ///
+    /// [`home_dir`]: #method.home_dir
     pub fn new() -> UserDirs {
         let home_dir  = env::home_dir().unwrap();
         let data_dir  = env::var_os("XDG_DATA_HOME").and_then(is_absolute_path).unwrap_or_else(|| home_dir.join(".local/share"));
@@ -68,6 +80,12 @@ impl ProjectDirs {
     /// 
     /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
     /// not follow operating system standards on at least two of three platforms.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
+    ///
+    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
     pub fn from_path(project_path: PathBuf) -> ProjectDirs {
         let home_dir       = env::home_dir().unwrap();
         let cache_dir      = env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).unwrap_or_else(|| home_dir.join(".cache")).join(&project_path);
@@ -101,6 +119,12 @@ impl ProjectDirs {
     ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`, `""`
     /// - `application`  – The name of the application itself.<br/>
     ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
+    ///
+    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
     #[allow(unused_variables)]
     pub fn from(qualifier: &str, organization: &str, application: &str) -> ProjectDirs {
         ProjectDirs::from_path(PathBuf::from(&trim_and_lowercase_then_replace_spaces(application, "")))

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -8,128 +8,73 @@ use BaseDirs;
 use UserDirs;
 use ProjectDirs;
 
-impl BaseDirs {
-    /// Creates a `BaseDirs` struct which holds the paths to user-invisible directories for cache, config, etc. data on the system.
-    /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`home_dir`].
-    ///
-    /// [`home_dir`]: #method.home_dir
-    pub fn new() -> BaseDirs {
-        let home_dir       = env::home_dir().unwrap();
-        let cache_dir      = home_dir.join("Library/Caches");
-        let config_dir     = home_dir.join("Library/Preferences");
-        let data_dir       = home_dir.join("Library/Application Support");
-        let data_local_dir = data_dir.clone();
+pub fn base_dirs() -> BaseDirs {
+    let home_dir       = env::home_dir().unwrap();
+    let cache_dir      = home_dir.join("Library/Caches");
+    let config_dir     = home_dir.join("Library/Preferences");
+    let data_dir       = home_dir.join("Library/Application Support");
+    let data_local_dir = data_dir.clone();
 
-        BaseDirs {
-            home_dir:       home_dir,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            executable_dir: None,
-            runtime_dir:    None
-        }
+    BaseDirs {
+        home_dir:       home_dir,
+        cache_dir:      cache_dir,
+        config_dir:     config_dir,
+        data_dir:       data_dir,
+        data_local_dir: data_local_dir,
+        executable_dir: None,
+        runtime_dir:    None
     }
 }
 
-impl UserDirs {
-    /// Creates a `UserDirs` struct which holds the paths to user-facing directories for audio, font, video, etc. data on the system.
-    /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`home_dir`].
-    ///
-    /// [`home_dir`]: #method.home_dir
-    pub fn new() -> UserDirs {
-        let home_dir       = env::home_dir().unwrap();
-        let audio_dir      = home_dir.join("Music");
-        let desktop_dir    = home_dir.join("Desktop");
-        let document_dir   = home_dir.join("Documents");
-        let download_dir   = home_dir.join("Downloads");
-        let picture_dir    = home_dir.join("Pictures");
-        let public_dir     = home_dir.join("Public");
-        // let trash_dir      = home_dir.join(".trash");
-        let video_dir      = home_dir.join("Movies");
-        let font_dir       = home_dir.join("Library/Fonts");
+pub fn user_dirs() -> UserDirs {
+    let home_dir       = env::home_dir().unwrap();
+    let audio_dir      = home_dir.join("Music");
+    let desktop_dir    = home_dir.join("Desktop");
+    let document_dir   = home_dir.join("Documents");
+    let download_dir   = home_dir.join("Downloads");
+    let picture_dir    = home_dir.join("Pictures");
+    let public_dir     = home_dir.join("Public");
+    // let trash_dir      = home_dir.join(".trash");
+    let video_dir      = home_dir.join("Movies");
+    let font_dir       = home_dir.join("Library/Fonts");
 
-        UserDirs {
-            home_dir:     home_dir,
-            audio_dir:    Some(audio_dir),
-            desktop_dir:  Some(desktop_dir),
-            document_dir: Some(document_dir),
-            download_dir: Some(download_dir),
-            font_dir:     Some(font_dir),
-            picture_dir:  Some(picture_dir),
-            public_dir:   Some(public_dir),
-            template_dir: None,
-            // trash_dir:    trash_dir,
-            video_dir:    Some(video_dir)
-        }
+    UserDirs {
+        home_dir:     home_dir,
+        audio_dir:    Some(audio_dir),
+        desktop_dir:  Some(desktop_dir),
+        document_dir: Some(document_dir),
+        download_dir: Some(download_dir),
+        font_dir:     Some(font_dir),
+        picture_dir:  Some(picture_dir),
+        public_dir:   Some(public_dir),
+        template_dir: None,
+        // trash_dir:    trash_dir,
+        video_dir:    Some(video_dir)
     }
 }
 
-impl ProjectDirs {
-    /// Creates a `ProjectDirs` struct directly from a `PathBuf` value.
-    /// The argument is used verbatim and is not adapted to operating system standards.
-    /// 
-    /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
-    /// not follow operating system standards on at least two of three platforms.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
-    ///
-    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
-    pub fn from_path(project_path: PathBuf) -> ProjectDirs {
-        let home_dir       = env::home_dir().unwrap();
-        let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
-        let config_dir     = home_dir.join("Library/Preferences").join(&project_path);
-        let data_dir       = home_dir.join("Library/Application Support").join(&project_path);
-        let data_local_dir = data_dir.clone();
+pub fn project_dirs_from_path(project_path: PathBuf) -> ProjectDirs {
+    let home_dir       = env::home_dir().unwrap();
+    let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
+    let config_dir     = home_dir.join("Library/Preferences").join(&project_path);
+    let data_dir       = home_dir.join("Library/Application Support").join(&project_path);
+    let data_local_dir = data_dir.clone();
 
-        ProjectDirs {
-            project_path:   project_path,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            runtime_dir:    None,
-        }
+    ProjectDirs {
+        project_path:   project_path,
+        cache_dir:      cache_dir,
+        config_dir:     config_dir,
+        data_dir:       data_dir,
+        data_local_dir: data_local_dir,
+        runtime_dir:    None,
     }
+}
 
-    /// Creates a `ProjectDirs` struct from values describing the project.
-    ///
-    /// The use of `ProjectDirs::from` (instead of `ProjectDirs::from_path`) is strongly encouraged,
-    /// as its results will follow operating system standards on Linux, macOS and Windows.
-    ///
-    /// # Parameters
-    ///
-    /// - `qualifier`    – The reverse domain name notation of the application, excluding the organization or application name itself.<br/>
-    ///   An empty string can be passed if no qualifier should be used (only affects macOS).<br/>
-    ///   Example values: `"com.example"`, `"org"`, `"uk.co"`, `"io"`, `""`
-    /// - `organization` – The name of the organization that develops this application, or for which the application is developed.<br/>
-    ///   An empty string can be passed if no organization should be used (only affects macOS and Windows).<br/>
-    ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`, `""`
-    /// - `application`  – The name of the application itself.<br/>
-    ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
-    ///
-    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
-    #[allow(unused_variables)]
-    pub fn from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
-        // we should replace more characters, according to RFC1034 identifier rules
-        let organization = organization.replace(" ", "-");
-        let project      = project.replace(" ", "-");
-        let mut parts    = vec![qualifier, &organization, &project]; parts.retain(|e| !e.is_empty());
-        let bundle_id    = parts.join(".");
-        ProjectDirs::from_path(PathBuf::from(bundle_id))
-    }
+pub fn project_dirs_from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
+    // we should replace more characters, according to RFC1034 identifier rules
+    let organization = organization.replace(" ", "-");
+    let project      = project.replace(" ", "-");
+    let mut parts    = vec![qualifier, &organization, &project]; parts.retain(|e| !e.is_empty());
+    let bundle_id    = parts.join(".");
+    ProjectDirs::from_path(PathBuf::from(bundle_id))
 }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -11,6 +11,12 @@ use ProjectDirs;
 impl BaseDirs {
     /// Creates a `BaseDirs` struct which holds the paths to user-invisible directories for cache, config, etc. data on the system.
     /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`home_dir`].
+    ///
+    /// [`home_dir`]: #method.home_dir
     pub fn new() -> BaseDirs {
         let home_dir       = env::home_dir().unwrap();
         let cache_dir      = home_dir.join("Library/Caches");
@@ -33,6 +39,12 @@ impl BaseDirs {
 impl UserDirs {
     /// Creates a `UserDirs` struct which holds the paths to user-facing directories for audio, font, video, etc. data on the system.
     /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`home_dir`].
+    ///
+    /// [`home_dir`]: #method.home_dir
     pub fn new() -> UserDirs {
         let home_dir       = env::home_dir().unwrap();
         let audio_dir      = home_dir.join("Music");
@@ -67,6 +79,12 @@ impl ProjectDirs {
     /// 
     /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
     /// not follow operating system standards on at least two of three platforms.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
+    ///
+    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
     pub fn from_path(project_path: PathBuf) -> ProjectDirs {
         let home_dir       = env::home_dir().unwrap();
         let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
@@ -99,6 +117,12 @@ impl ProjectDirs {
     ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`, `""`
     /// - `application`  – The name of the application itself.<br/>
     ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
+    ///
+    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
     #[allow(unused_variables)]
     pub fn from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
         // we should replace more characters, according to RFC1034 identifier rules

--- a/src/win.rs
+++ b/src/win.rs
@@ -19,6 +19,12 @@ use ProjectDirs;
 impl BaseDirs {
     /// Creates a `BaseDirs` struct which holds the paths to user-invisible directories for cache, config, etc. data on the system.
     /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`home_dir`].
+    ///
+    /// [`home_dir`]: #method.home_dir
     pub fn new() -> BaseDirs {
         let home_dir       = unsafe { known_folder(&knownfolders::FOLDERID_Profile) };
         let data_dir       = unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) };
@@ -41,6 +47,12 @@ impl BaseDirs {
 impl UserDirs {
     /// Creates a `UserDirs` struct which holds the paths to user-facing directories for audio, font, video, etc. data on the system.
     /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`home_dir`].
+    ///
+    /// [`home_dir`]: #method.home_dir
     pub fn new() -> UserDirs {
         let home_dir       = unsafe { known_folder(&knownfolders::FOLDERID_Profile) };
         let audio_dir      = unsafe { known_folder(&knownfolders::FOLDERID_Music) };
@@ -76,6 +88,12 @@ impl ProjectDirs {
     /// 
     /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
     /// not follow operating system standards on at least two of three platforms.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
+    ///
+    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
     pub fn from_path(project_path: PathBuf) -> ProjectDirs {
         let app_data_local   = unsafe { known_folder(&knownfolders::FOLDERID_LocalAppData) }.join(&project_path);
         let app_data_roaming = unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) }.join(&project_path);
@@ -109,6 +127,12 @@ impl ProjectDirs {
     ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`, `""`
     /// - `application`  – The name of the application itself.<br/>
     ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
+    ///
+    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
     #[allow(unused_variables)]
     pub fn from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
         ProjectDirs::from_path(PathBuf::from_iter(&[organization, project]))

--- a/src/win.rs
+++ b/src/win.rs
@@ -16,127 +16,72 @@ use BaseDirs;
 use UserDirs;
 use ProjectDirs;
 
-impl BaseDirs {
-    /// Creates a `BaseDirs` struct which holds the paths to user-invisible directories for cache, config, etc. data on the system.
-    /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`home_dir`].
-    ///
-    /// [`home_dir`]: #method.home_dir
-    pub fn new() -> BaseDirs {
-        let home_dir       = unsafe { known_folder(&knownfolders::FOLDERID_Profile) };
-        let data_dir       = unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) };
-        let data_local_dir = unsafe { known_folder(&knownfolders::FOLDERID_LocalAppData) };
-        let cache_dir      = data_local_dir.clone();
-        let config_dir     = data_dir.clone();
+pub fn base_dirs() -> BaseDirs {
+    let home_dir       = unsafe { known_folder(&knownfolders::FOLDERID_Profile) };
+    let data_dir       = unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) };
+    let data_local_dir = unsafe { known_folder(&knownfolders::FOLDERID_LocalAppData) };
+    let cache_dir      = data_local_dir.clone();
+    let config_dir     = data_dir.clone();
 
-        BaseDirs {
-            home_dir:       home_dir,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            executable_dir: None,
-            runtime_dir:    None
-        }
+    BaseDirs {
+        home_dir:       home_dir,
+        cache_dir:      cache_dir,
+        config_dir:     config_dir,
+        data_dir:       data_dir,
+        data_local_dir: data_local_dir,
+        executable_dir: None,
+        runtime_dir:    None
     }
 }
 
-impl UserDirs {
-    /// Creates a `UserDirs` struct which holds the paths to user-facing directories for audio, font, video, etc. data on the system.
-    /// The returned struct is a snapshot of the state of the system at the time `new()` was invoked.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`home_dir`].
-    ///
-    /// [`home_dir`]: #method.home_dir
-    pub fn new() -> UserDirs {
-        let home_dir       = unsafe { known_folder(&knownfolders::FOLDERID_Profile) };
-        let audio_dir      = unsafe { known_folder(&knownfolders::FOLDERID_Music) };
-        let desktop_dir    = unsafe { known_folder(&knownfolders::FOLDERID_Desktop) };
-        let document_dir   = unsafe { known_folder(&knownfolders::FOLDERID_Documents) };
-        let download_dir   = unsafe { known_folder(&knownfolders::FOLDERID_Downloads) };
-        let picture_dir    = unsafe { known_folder(&knownfolders::FOLDERID_Pictures) };
-        let public_dir     = unsafe { known_folder(&knownfolders::FOLDERID_Public) };
-        let template_dir   = unsafe { known_folder(&knownfolders::FOLDERID_Templates) };
-        // see https://github.com/soc/directories-rs/issues/18
-        // let trash_dir      = unsafe { known_folder(&knownfolders::FOLDERID_RecycleBinFolder) };
-        let video_dir      = unsafe { known_folder(&knownfolders::FOLDERID_Videos) };
+pub fn user_dirs() -> UserDirs {
+    let home_dir       = unsafe { known_folder(&knownfolders::FOLDERID_Profile) };
+    let audio_dir      = unsafe { known_folder(&knownfolders::FOLDERID_Music) };
+    let desktop_dir    = unsafe { known_folder(&knownfolders::FOLDERID_Desktop) };
+    let document_dir   = unsafe { known_folder(&knownfolders::FOLDERID_Documents) };
+    let download_dir   = unsafe { known_folder(&knownfolders::FOLDERID_Downloads) };
+    let picture_dir    = unsafe { known_folder(&knownfolders::FOLDERID_Pictures) };
+    let public_dir     = unsafe { known_folder(&knownfolders::FOLDERID_Public) };
+    let template_dir   = unsafe { known_folder(&knownfolders::FOLDERID_Templates) };
+    // see https://github.com/soc/directories-rs/issues/18
+    // let trash_dir      = unsafe { known_folder(&knownfolders::FOLDERID_RecycleBinFolder) };
+    let video_dir      = unsafe { known_folder(&knownfolders::FOLDERID_Videos) };
 
-        UserDirs {
-            home_dir:     home_dir,
-            audio_dir:    Some(audio_dir),
-            desktop_dir:  Some(desktop_dir),
-            document_dir: Some(document_dir),
-            download_dir: Some(download_dir),
-            font_dir:     None,
-            picture_dir:  Some(picture_dir),
-            public_dir:   Some(public_dir),
-            template_dir: Some(template_dir),
-            // trash_dir:    trash_dir,
-            video_dir:    Some(video_dir)
-        }
+    UserDirs {
+        home_dir:     home_dir,
+        audio_dir:    Some(audio_dir),
+        desktop_dir:  Some(desktop_dir),
+        document_dir: Some(document_dir),
+        download_dir: Some(download_dir),
+        font_dir:     None,
+        picture_dir:  Some(picture_dir),
+        public_dir:   Some(public_dir),
+        template_dir: Some(template_dir),
+        // trash_dir:    trash_dir,
+        video_dir:    Some(video_dir)
     }
 }
 
-impl ProjectDirs {
-    /// Creates a `ProjectDirs` struct directly from a `PathBuf` value.
-    /// The argument is used verbatim and is not adapted to operating system standards.
-    /// 
-    /// The use of `ProjectDirs::from_path` is strongly discouraged, as its results will
-    /// not follow operating system standards on at least two of three platforms.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
-    ///
-    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
-    pub fn from_path(project_path: PathBuf) -> ProjectDirs {
-        let app_data_local   = unsafe { known_folder(&knownfolders::FOLDERID_LocalAppData) }.join(&project_path);
-        let app_data_roaming = unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) }.join(&project_path);
-        let cache_dir      = app_data_local.join("cache");
-        let data_local_dir = app_data_local.join("data");
-        let config_dir     = app_data_roaming.join("config");
-        let data_dir       = app_data_roaming.join("data");
+pub fn project_dirs_from_path(project_path: PathBuf) -> ProjectDirs {
+    let app_data_local   = unsafe { known_folder(&knownfolders::FOLDERID_LocalAppData) }.join(&project_path);
+    let app_data_roaming = unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) }.join(&project_path);
+    let cache_dir      = app_data_local.join("cache");
+    let data_local_dir = app_data_local.join("data");
+    let config_dir     = app_data_roaming.join("config");
+    let data_dir       = app_data_roaming.join("data");
 
-        ProjectDirs {
-            project_path:   project_path,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            runtime_dir:    None
-        }
+    ProjectDirs {
+        project_path:   project_path,
+        cache_dir:      cache_dir,
+        config_dir:     config_dir,
+        data_dir:       data_dir,
+        data_local_dir: data_local_dir,
+        runtime_dir:    None
     }
+}
 
-    /// Creates a `ProjectDirs` struct from values describing the project.
-    ///
-    /// The use of `ProjectDirs::from` (instead of `ProjectDirs::from_path`) is strongly encouraged,
-    /// as its results will follow operating system standards on Linux, macOS and Windows.
-    ///
-    /// # Parameters
-    ///
-    /// - `qualifier`    – The reverse domain name notation of the application, excluding the organization or application name itself.<br/>
-    ///   An empty string can be passed if no qualifier should be used (only affects macOS).<br/>
-    ///   Example values: `"com.example"`, `"org"`, `"uk.co"`, `"io"`, `""`
-    /// - `organization` – The name of the organization that develops this application, or for which the application is developed.<br/>
-    ///   An empty string can be passed if no organization should be used (only affects macOS and Windows).<br/>
-    ///   Example values: `"Foo Corp"`, `"Alice and Bob Inc"`, `""`
-    /// - `application`  – The name of the application itself.<br/>
-    ///   Example values: `"Bar App"`, `"ExampleProgram"`, `"Unicorn-Programme"`
-    ///
-    /// # Panics
-    ///
-    /// Panics if the home directory cannot be determined. See [`BaseDirs::home_dir`].
-    ///
-    /// [`BaseDirs::home_dir`]: struct.BaseDirs.html#method.home_dir
-    #[allow(unused_variables)]
-    pub fn from(qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
-        ProjectDirs::from_path(PathBuf::from_iter(&[organization, project]))
-    }
+pub fn project_dirs_from(_qualifier: &str, organization: &str, project: &str) -> ProjectDirs {
+    ProjectDirs::from_path(PathBuf::from_iter(&[organization, project]))
 }
 
 unsafe fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> PathBuf {


### PR DESCRIPTION
Describe when the constructor methods panic. Make the wording around
home directories on non-Windows more precise. Fix some typos.