### PR TITLE
Fix readme for executable_dir on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ proj_dirs.config_dir();
 
 let base_dirs = BaseDirs::new();
 base_dirs.executable_dir();
-// Lin: Some(/home/alice/.local/share/bin)
+// Lin: Some(/home/alice/.local/bin)
 // Win: None
 // Mac: None
 


### PR DESCRIPTION
We pop `share` over here I think: https://github.com/soc/directories-rs/blob/62ba8f3412fb40b70d27f34d1df2f645560f8c19/src/lin.rs#L25