### PR TITLE
Improve compatibility with older Rust versions

### DIFF
--- a/src/lin.rs
+++ b/src/lin.rs
@@ -81,7 +81,10 @@ fn is_absolute_path(path: OsString) -> Option<PathBuf> {
 
 fn run_xdg_user_dir_command(arg: &str) -> Option<PathBuf> {
     use std::os::unix::ffi::OsStringExt;
-    let mut out  = Command::new("xdg-user-dir").arg(arg).output().ok()?.stdout;
+    let mut out = match Command::new("xdg-user-dir").arg(arg).output() {
+        Ok(output) => output.stdout,
+        Err(_) => return None,
+    };
     let out_len = out.len();
     out.truncate(out_len - 1);
     Some(PathBuf::from(OsString::from_vec(out)))


### PR DESCRIPTION
Previously, the `lin` module required Rust 1.22 or newer. It now
compiles with 1.14.