### PR TITLE
CI: Add Rust 1.13.0 build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,11 @@ environment:
     CHANNEL: beta
   - TARGET: x86_64-pc-windows-gnu
     CHANNEL: beta
+  # 1.13.0
+  - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: 1.13.0
+  - TARGET: x86_64-pc-windows-gnu
+    CHANNEL: 1.13.0
 
 install:
 - ps: >-
@@ -29,7 +34,7 @@ install:
 - cargo -V
 
 test_script:
-- cargo check --verbose
+- cargo build --verbose
 - set RUST_BACKTRACE=full
 - cargo test --verbose -- --nocapture
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ language: rust
 rust:
 - stable
 - beta
+- 1.13.0
 
 install:
 - rustc -Vv
 - cargo -V
 
 script:
-- cargo check --verbose
+- cargo build --verbose
 - RUST_BACKTRACE=full cargo test --verbose -- --nocapture
 
 cache:


### PR DESCRIPTION
This adds an additional build for a fixed Rust version to avoid
accidentally depending on a newer version.

Fixes #32 

It took two failed attempts (sorry for the Spam), but now the builds actually pass!